### PR TITLE
Add stub endpoints for upcoming features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project provides an AI-powered web application that helps users get insight
 - **Statistical Summary**: View basic statistical summaries of your data.
 - **Natural Language Queries**: Ask questions about your data in plain English.
 - **Formula Generation**: Get suggestions for Excel formulas based on your data.
+- **Upcoming Features**: Initial placeholders exist for automated data cleaning, chart generation, template library, macro generation, predictive analytics, collaboration, developer API, spreadsheet add-ins, multilingual support, and usage analytics.
 
 ## Project Structure
 

--- a/excel_ai_backend/src/main.py
+++ b/excel_ai_backend/src/main.py
@@ -19,6 +19,7 @@ from src.routes.formula import formula_bp
 from src.routes.google_sheets import google_sheets_bp
 from src.routes.telemetry import telemetry_bp
 from src.routes.chat import chat_bp
+from src.routes.features import features_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = os.getenv('FLASK_SECRET_KEY', 'fallback-secret-key')
@@ -35,6 +36,7 @@ app.register_blueprint(formula_bp, url_prefix='/api/v1/formula', name='formula_v
 app.register_blueprint(google_sheets_bp, url_prefix='/api/v1/google-sheets', name='google_sheets_v1')
 app.register_blueprint(telemetry_bp, url_prefix='/api/v1/telemetry', name='telemetry_v1')
 app.register_blueprint(chat_bp, url_prefix='/api/v1/chat', name='chat_v1')
+app.register_blueprint(features_bp, url_prefix='/api/v1/features', name='features_v1')
 
 # Legacy support - redirect old API calls to v1
 app.register_blueprint(user_bp, url_prefix='/api', name='user_legacy')
@@ -98,6 +100,18 @@ def api_info():
                 'list': '/api/v1/users',
                 'create': '/api/v1/users',
                 'get': '/api/v1/users/{id}'
+            },
+            'features': {
+                'data_cleaning': '/api/v1/features/data-cleaning',
+                'chart_builder': '/api/v1/features/chart-builder',
+                'templates': '/api/v1/features/templates',
+                'macro_generation': '/api/v1/features/macro-generation',
+                'predictive_analytics': '/api/v1/features/predictive-analytics',
+                'collaboration': '/api/v1/features/collaboration',
+                'developer_api': '/api/v1/features/developer-api',
+                'add_in': '/api/v1/features/add-in',
+                'multilingual': '/api/v1/features/multilingual',
+                'usage_analytics': '/api/v1/features/usage-analytics'
             }
         }
     })

--- a/excel_ai_backend/src/routes/features.py
+++ b/excel_ai_backend/src/routes/features.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, jsonify
+
+features_bp = Blueprint('features', __name__)
+
+def _placeholder(name: str):
+    """Return a standard placeholder response for in-progress features."""
+    return jsonify({"feature": name, "status": "in-progress"})
+
+@features_bp.route('/data-cleaning', methods=['GET'])
+def data_cleaning():
+    return _placeholder('Automated Data Cleaning')
+
+@features_bp.route('/chart-builder', methods=['GET'])
+def chart_builder():
+    return _placeholder('Interactive Chart & Dashboard Builder')
+
+@features_bp.route('/templates', methods=['GET'])
+def templates():
+    return _placeholder('Template & Snippet Library')
+
+@features_bp.route('/macro-generation', methods=['GET'])
+def macro_generation():
+    return _placeholder('Macro / Script Generation')
+
+@features_bp.route('/predictive-analytics', methods=['GET'])
+def predictive_analytics():
+    return _placeholder('Predictive & Prescriptive Analytics')
+
+@features_bp.route('/collaboration', methods=['GET'])
+def collaboration():
+    return _placeholder('Real-time Collaboration')
+
+@features_bp.route('/developer-api', methods=['GET'])
+def developer_api():
+    return _placeholder('Developer API & Integrations')
+
+@features_bp.route('/add-in', methods=['GET'])
+def add_in():
+    return _placeholder('Excel/Sheets Add-in')
+
+@features_bp.route('/multilingual', methods=['GET'])
+def multilingual():
+    return _placeholder('Multilingual & Accessibility Support')
+
+@features_bp.route('/usage-analytics', methods=['GET'])
+def usage_analytics():
+    return _placeholder('Usage Analytics & Admin Dashboard')


### PR DESCRIPTION
## Summary
- add placeholder API routes for ten planned features
- expose feature endpoints via main API and update documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964c0d46788330bf6fe4a5cb4bf5e7