### PR TITLE
fix: remove unused FocusTrap import

### DIFF
--- a/excel-ai-frontend/src/components/EnhancedUI.jsx
+++ b/excel-ai-frontend/src/components/EnhancedUI.jsx
@@ -3,7 +3,7 @@ import { AnimatedButton } from './ui/AnimatedButton';
 import { ThemeToggle } from './ui/ThemeToggle';
 import { FaviconManager } from './FaviconManager';
 import { AnalyticsProvider, CookieConsentBanner, SectionTracker, useAnalytics } from './Analytics';
-import { AccessibleProgress, LiveRegion, SkipToContent, FocusTrap } from './ui/Accessibility';
+import { AccessibleProgress, LiveRegion, SkipToContent } from './ui/Accessibility';
 
 // Enhanced Loading Component with Analytics
 export const EnhancedLoading = ({ 


### PR DESCRIPTION
## Summary
- fix build-time error by removing unused `FocusTrap` import

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install chromium` *(fails: Download failed 403 Forbidden)*
- `npm run lint` *(fails: 69 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b948366888330aa48624124d56072